### PR TITLE
docs: replace default README with portfolio documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,90 @@
-# React + Vite
+# Mikkel Martinus Fahnoee – Portfolio
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A personal portfolio website built with **React**, **Vite**, and **Tailwind CSS**.
 
-Currently, two official plugins are available:
+## Live Site
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- **GitHub Pages:** https://fahnoee.github.io
+
+## Features
+
+- Single-page portfolio layout
+- Sections for Hero, Projects, Skills, and Contact
+- Responsive styling with Tailwind CSS
+- Easy-to-edit content through data files in `src/data`
+
+## Tech Stack
+
+- React 18
+- Vite 5
+- Tailwind CSS
+- ESLint
+- GitHub Pages (`gh-pages`)
+
+## Project Structure
+
+```text
+src/
+  components/      # UI sections (Hero, Projects, Skills, Contact)
+  data/            # Portfolio content (personal info, skills, projects)
+  images/          # Static image assets used by projects
+```
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js (v18+ recommended)
+- npm
+
+### Installation
+
+```bash
+npm install
+```
+
+### Run in Development
+
+```bash
+npm run dev
+```
+
+### Build for Production
+
+```bash
+npm run build
+```
+
+### Preview Production Build
+
+```bash
+npm run preview
+```
+
+## Linting
+
+```bash
+npm run lint
+```
+
+## Deployment
+
+This repo is configured to deploy the `dist` folder to GitHub Pages.
+
+```bash
+npm run deploy
+```
+
+The deployment flow automatically runs `npm run build` via `predeploy`.
+
+## Customizing Portfolio Content
+
+Update these files to personalize the portfolio:
+
+- `src/data/personal.js`
+- `src/data/projects.js`
+- `src/data/skills.js`
+
+## License
+
+This project is for personal portfolio use.


### PR DESCRIPTION
### Motivation
- Replace the generic Vite starter README with a project-specific guide so contributors and future self can quickly understand this portfolio site.
- Surface the live site URL, tech stack, project structure, and common workflows (dev/build/lint/deploy) for easier onboarding.
- Point editors to the data files used to customize the portfolio content.

### Description
- Rewrote `README.md` to `Mikkel Martinus Fahnoee – Portfolio` and added sections for Live Site, Features, Tech Stack, Project Structure, Getting Started, Linting, Deployment, and Customizing Portfolio Content.
- Documented common commands: `npm install`, `npm run dev`, `npm run build`, `npm run preview`, `npm run lint`, and `npm run deploy`.
- Noted where to update portfolio content (`src/data/personal.js`, `src/data/projects.js`, `src/data/skills.js`).

### Testing
- Ran `npm run build` which completed successfully and produced a production build. (✅)
- Ran `npm run lint` which failed due to existing ESLint errors in source files unrelated to the README change, reporting 13 problems across component files. (❌)
- No runtime or functionality code changes were made, so existing app behavior was not modified by this documentation update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995ee66a1c8832f9171302edf7876b7)